### PR TITLE
fix for character creation AFK

### DIFF
--- a/Contents/mods/AwayFromZomboid/media/lua/client/AwayFromZomboid/AwayFromZomboid.lua
+++ b/Contents/mods/AwayFromZomboid/media/lua/client/AwayFromZomboid/AwayFromZomboid.lua
@@ -53,7 +53,8 @@ end
 ---@param message string
 ---@return void
 AwayFromZomboid.sendChatNotification = function(message)
-    processGeneralMessage(message)
+    -- processGeneralMessage(message)
+    getPlayer():Say(message)
 end
 
 -- Fetch sandbox vars
@@ -224,10 +225,8 @@ end
 ---@return void
 AwayFromZomboid.AFKOnPopup = function()
     -- setHaloNote(param1, param2, param3, param4, param5) -- param1 = text, param2 = r, param3 = g, param4 = b, param5 = duration(in ticks)
-    -- 1 secondo reale ≈ 60 tick
     -- duration in ticks = seconds * 60
     getPlayer():setHaloNote(AwayFromZomboid.getAFKOnPopupMessage(), 255, 0, 0, (SandboxVars.AwayFromZomboid.AFKKickTimeout*60)+500)
-    -- HaloTextHelper.addText(getPlayer(), AwayFromZomboid.getAFKOnPopupMessage(), HaloTextHelper.getColorRed())
     local message = AwayFromZomboid.getAFKOnPopupMessage()
     if AwayFromZomboid.getDoKick() then
         message = message .. " (Kick in " .. AwayFromZomboid.getAFKKickTimeout() .. " seconds)"
@@ -239,7 +238,6 @@ end
 ---@return void
 AwayFromZomboid.AFKOffPopup = function()
     getPlayer():setHaloNote(AwayFromZomboid.getAFKOffPopupMessage(), 0, 255, 0, 500)
-    -- HaloTextHelper.addText(getPlayer(), AwayFromZomboid.getAFKOffPopupMessage(), HaloTextHelper.getColorGreen())
     AwayFromZomboid.sendChatNotification(AwayFromZomboid.getAFKOffPopupMessage())
 end
 
@@ -312,9 +310,13 @@ end
 ---@return void
 AwayFromZomboid.manualAFKHook = function(chatMessage, tabId)
     if AwayFromZomboid.getAllowManualAFK() then
-        if (chatMessage:getText() == "AFK" or chatMessage:getText() == "afk" or chatMessage:getText() == "Afk") and chatMessage:getAuthor() == getPlayer():getUsername() then
-            AwayFromZomboid.sendChatNotification("You will become AFK in ~" .. AwayFromZomboid.getManualAFKDelay() .. " seconds.")
-            AwayFromZomboid.lateTimerAddition = AwayFromZomboid.getAFKTimeout() - AwayFromZomboid.getManualAFKDelay()
+        if chatMessage:getAuthor() == getPlayer():getUsername() then
+            local fullMessage = chatMessage:getText()
+            local extractedMessage = fullMessage:match('"(.-)"')
+            if string.lower(extractedMessage) == "afk." then
+                AwayFromZomboid.sendChatNotification("You will become AFK in ~" .. AwayFromZomboid.getManualAFKDelay() .. " seconds.")
+                AwayFromZomboid.lateTimerAddition = AwayFromZomboid.getAFKTimeout() - AwayFromZomboid.getManualAFKDelay()
+            end
         end
     end
 end

--- a/Contents/mods/AwayFromZomboid/media/lua/client/AwayFromZomboid/AwayFromZomboid.lua
+++ b/Contents/mods/AwayFromZomboid/media/lua/client/AwayFromZomboid/AwayFromZomboid.lua
@@ -359,11 +359,13 @@ end
 -- Init hook
 
 Events.OnCreatePlayer.Add(AwayFromZomboid.init)
-Events.OnCharacterDeath.Add(function (player)
-    AwayFromZomboid.resetAFKTimer()
-    AwayFromZomboid.isAFK = false
-    Events.EveryOneMinute.Remove(AwayFromZomboid.incrementAFKHook)
-    Events.OnAddMessage.Remove(AwayFromZomboid.manualAFKHook)
-    AwayFromZomboid.log(AwayFromZomboid.modVersion .. " Character death.")
+Events.OnPlayerDeath.Add(function (player)
+    if getPlayer():isDead() then
+        AwayFromZomboid.resetAFKTimer()
+        AwayFromZomboid.isAFK = false
+        Events.EveryOneMinute.Remove(AwayFromZomboid.incrementAFKHook)
+        Events.OnAddMessage.Remove(AwayFromZomboid.manualAFKHook)
+        AwayFromZomboid.log(AwayFromZomboid.modVersion .. " Character death.")
+    end
 
 end)

--- a/Contents/mods/AwayFromZomboid/media/lua/client/AwayFromZomboid/AwayFromZomboid.lua
+++ b/Contents/mods/AwayFromZomboid/media/lua/client/AwayFromZomboid/AwayFromZomboid.lua
@@ -223,7 +223,11 @@ end
 --- Popup the AFK message.
 ---@return void
 AwayFromZomboid.AFKOnPopup = function()
-    HaloTextHelper.addText(getPlayer(), AwayFromZomboid.getAFKOnPopupMessage(), HaloTextHelper.getColorRed())
+    -- setHaloNote(param1, param2, param3, param4, param5) -- param1 = text, param2 = r, param3 = g, param4 = b, param5 = duration(in ticks)
+    -- 1 secondo reale ≈ 60 tick
+    -- duration in ticks = seconds * 60
+    getPlayer():setHaloNote(AwayFromZomboid.getAFKOnPopupMessage(), 255, 0, 0, (SandboxVars.AwayFromZomboid.AFKKickTimeout*60)+500)
+    -- HaloTextHelper.addText(getPlayer(), AwayFromZomboid.getAFKOnPopupMessage(), HaloTextHelper.getColorRed())
     local message = AwayFromZomboid.getAFKOnPopupMessage()
     if AwayFromZomboid.getDoKick() then
         message = message .. " (Kick in " .. AwayFromZomboid.getAFKKickTimeout() .. " seconds)"
@@ -234,7 +238,8 @@ end
 --- Popup the not AFK message.
 ---@return void
 AwayFromZomboid.AFKOffPopup = function()
-    HaloTextHelper.addText(getPlayer(), AwayFromZomboid.getAFKOffPopupMessage(), HaloTextHelper.getColorGreen())
+    getPlayer():setHaloNote(AwayFromZomboid.getAFKOffPopupMessage(), 0, 255, 0, 500)
+    -- HaloTextHelper.addText(getPlayer(), AwayFromZomboid.getAFKOffPopupMessage(), HaloTextHelper.getColorGreen())
     AwayFromZomboid.sendChatNotification(AwayFromZomboid.getAFKOffPopupMessage())
 end
 
@@ -307,7 +312,7 @@ end
 ---@return void
 AwayFromZomboid.manualAFKHook = function(chatMessage, tabId)
     if AwayFromZomboid.getAllowManualAFK() then
-        if chatMessage:getText() == "afk" and chatMessage:getAuthor() == getPlayer():getUsername() then
+        if (chatMessage:getText() == "AFK" or chatMessage:getText() == "afk" or chatMessage:getText() == "Afk") and chatMessage:getAuthor() == getPlayer():getUsername() then
             AwayFromZomboid.sendChatNotification("You will become AFK in ~" .. AwayFromZomboid.getManualAFKDelay() .. " seconds.")
             AwayFromZomboid.lateTimerAddition = AwayFromZomboid.getAFKTimeout() - AwayFromZomboid.getManualAFKDelay()
         end

--- a/Contents/mods/AwayFromZomboid/media/lua/client/AwayFromZomboid/AwayFromZomboid.lua
+++ b/Contents/mods/AwayFromZomboid/media/lua/client/AwayFromZomboid/AwayFromZomboid.lua
@@ -353,4 +353,12 @@ end
 
 -- Init hook
 
-Events.OnConnected.Add(AwayFromZomboid.init)
+Events.OnCreatePlayer.Add(AwayFromZomboid.init)
+Events.OnCharacterDeath.Add(function (player)
+    AwayFromZomboid.resetAFKTimer()
+    AwayFromZomboid.isAFK = false
+    Events.EveryOneMinute.Remove(AwayFromZomboid.incrementAFKHook)
+    Events.OnAddMessage.Remove(AwayFromZomboid.manualAFKHook)
+    AwayFromZomboid.log(AwayFromZomboid.modVersion .. " Character death.")
+
+end)


### PR DESCRIPTION
An idea came to me to fix the AFK problem during character creation! As you can see, there's the OnCharacterDeath event, which is perfect. I remove the other events upon death, and they are reinitialized when the character is created. Consider that I replaced the OnConnected event with OnCreatePlayer because the latter is not an event that occurs when the player is created during character creation, but it's an event that's triggered when the IsoPlayer is generated during login. So, in theory, it should work smoothly both at login with an already created character and after character creation post-death. If you have a way to test the build this way—otherwise, I'll do it shortly—but I'm quite sure it will work.






